### PR TITLE
Feature vision improv - Tuning and Image Saving

### DIFF
--- a/op3_ball_detector/CMakeLists.txt
+++ b/op3_ball_detector/CMakeLists.txt
@@ -52,12 +52,14 @@ add_message_files(
   FILES
   CircleSetStamped.msg
   BallDetectorParams.msg
+  SaveImageParams.msg
 )
 
 add_service_files(
   FILES
   GetParameters.srv
   SetParameters.srv
+  SaveImage.srv
 )
 
 generate_messages(

--- a/op3_ball_detector/config/ball_detector_params.yaml
+++ b/op3_ball_detector/config/ball_detector_params.yaml
@@ -6,11 +6,11 @@ min_circle_dist: 100
 hough_accum_th: 28
 min_radius: 20
 max_radius: 300
-filter_h_min: 355
-filter_h_max: 25
-filter_s_min: 220
+filter_h_min: 229
+filter_h_max: 12
+filter_s_min: 180
 filter_s_max: 255
-filter_v_min: 80
+filter_v_min: 0
 filter_v_max: 255
 use_second_filter: false
 filter2_h_min: 30

--- a/op3_ball_detector/include/op3_ball_detector/ball_detector.h
+++ b/op3_ball_detector/include/op3_ball_detector/ball_detector.h
@@ -81,7 +81,7 @@ class BallDetector
   void paramCommandCallback(const std_msgs::String::ConstPtr &msg);
   bool setParamCallback(op3_ball_detector::SetParameters::Request &req, op3_ball_detector::SetParameters::Response &res);
   bool getParamCallback(op3_ball_detector::GetParameters::Request &req, op3_ball_detector::GetParameters::Response &res);
-  
+
   bool saveImageCallback(op3_ball_detector::SaveImage::Request &req, op3_ball_detector::SaveImage::Response &res);
 
   void resetParameter();
@@ -138,6 +138,7 @@ class BallDetector
   ros::Subscriber param_command_sub_;
   ros::ServiceServer get_param_client_;
   ros::ServiceServer set_param_client_;
+  ros::ServiceServer save_image_client_;
 
   //flag indicating a new image has been received
   bool new_image_flag_;

--- a/op3_ball_detector/include/op3_ball_detector/ball_detector.h
+++ b/op3_ball_detector/include/op3_ball_detector/ball_detector.h
@@ -43,6 +43,8 @@
 #include "op3_ball_detector/GetParameters.h"
 #include "op3_ball_detector/SetParameters.h"
 
+#include "op3_ball_detector/SaveImage.h"
+
 namespace robotis_op
 {
 
@@ -79,6 +81,9 @@ class BallDetector
   void paramCommandCallback(const std_msgs::String::ConstPtr &msg);
   bool setParamCallback(op3_ball_detector::SetParameters::Request &req, op3_ball_detector::SetParameters::Response &res);
   bool getParamCallback(op3_ball_detector::GetParameters::Request &req, op3_ball_detector::GetParameters::Response &res);
+  
+  bool saveImageCallback(op3_ball_detector::SaveImage::Request &req, op3_ball_detector::SaveImage::Response &res);
+
   void resetParameter();
   void publishParam();
 

--- a/op3_ball_detector/include/op3_ball_detector/ball_detector.h
+++ b/op3_ball_detector/include/op3_ball_detector/ball_detector.h
@@ -29,6 +29,7 @@
 #include <sensor_msgs/image_encodings.h>
 #include <dynamic_reconfigure/server.h>
 #include <cv_bridge/cv_bridge.h>
+#include <opencv2/opencv.hpp>
 #include <image_transport/image_transport.h>
 
 #include <opencv2/core/core.hpp>

--- a/op3_ball_detector/msg/SaveImageParams.msg
+++ b/op3_ball_detector/msg/SaveImageParams.msg
@@ -1,0 +1,2 @@
+# Test
+uint32 test

--- a/op3_ball_detector/msg/SaveImageParams.msg
+++ b/op3_ball_detector/msg/SaveImageParams.msg
@@ -1,2 +1,2 @@
 # Test
-uint32 test
+string name

--- a/op3_ball_detector/src/ball_detector.cpp
+++ b/op3_ball_detector/src/ball_detector.cpp
@@ -350,7 +350,7 @@ bool BallDetector::saveImageCallback(op3_ball_detector::SaveImage::Request &req,
   ROS_DEBUG("Hello, your number is %d", req.params.test);
 
   if (cv_img_ptr_sub_ != NULL) {
-    cv::imwrite("~/out.png", cv_img_ptr_sub_->image);
+    cv::imwrite("/home/robotis/out.png", cv_img_ptr_sub_->image);
     res.returns.test = 0;
   }
   else {

--- a/op3_ball_detector/src/ball_detector.cpp
+++ b/op3_ball_detector/src/ball_detector.cpp
@@ -351,7 +351,9 @@ bool BallDetector::saveImageCallback(op3_ball_detector::SaveImage::Request &req,
     if (cv::imwrite(filename, cv_img_ptr_sub_->image) == false) {
       res.returns.name = "Failed for some reason";
     }
-    res.returns.name = "Saved";
+    else {
+      res.returns.name = "Saved";
+    }
   }
   else {
     res.returns.name = "Not Saved";

--- a/op3_ball_detector/src/ball_detector.cpp
+++ b/op3_ball_detector/src/ball_detector.cpp
@@ -346,15 +346,15 @@ bool BallDetector:: getParamCallback(op3_ball_detector::GetParameters::Request &
 // Callback for image saving
 bool BallDetector::saveImageCallback(op3_ball_detector::SaveImage::Request &req, op3_ball_detector::SaveImage::Response &res)
 {
-  // Basic debug statement to start
-  ROS_DEBUG("Hello, your number is %d", req.params.test);
-
+  std::string filename = "/home/robotis/" + req.params.name + ".png";
   if (cv_img_ptr_sub_ != NULL) {
-    cv::imwrite("/home/robotis/out.png", cv_img_ptr_sub_->image);
-    res.returns.test = 0;
+    if (cv::imwrite(filename, cv_img_ptr_sub_->image) == false) {
+      res.returns.name = "Failed for some reason";
+    }
+    res.returns.name = "Saved";
   }
   else {
-    res.returns.test = 1;
+    res.returns.name = "Not Saved";
   }
 
   return true;

--- a/op3_ball_detector/src/ball_detector.cpp
+++ b/op3_ball_detector/src/ball_detector.cpp
@@ -91,6 +91,7 @@ BallDetector::BallDetector()
   param_command_sub_ = nh_.subscribe("param_command", 1, &BallDetector::paramCommandCallback, this);
   set_param_client_ = nh_.advertiseService("set_param", &BallDetector::setParamCallback, this);
   get_param_client_ = nh_.advertiseService("get_param", &BallDetector::getParamCallback, this);
+  save_image_client_ = nh_.advertiseService("save_image", &BallDetector::saveImageCallback, this);
   default_setting_path_ = ros::package::getPath(ROS_PACKAGE_NAME) + "/config/ball_detector_params_default.yaml";
 
   //sets config and prints it
@@ -339,6 +340,14 @@ bool BallDetector:: getParamCallback(op3_ball_detector::GetParameters::Request &
   res.returns.filter_v_max = params_config_.filter_threshold.v_max;
   res.returns.ellipse_size = params_config_.ellipse_size;
 
+  return true;
+}
+
+// Callback for image saving
+bool BallDetector::saveImageCallback(op3_ball_detector::SaveImage::Request &req, op3_ball_detector::SaveImage::Response &res)
+{
+  // Basic debug statement to start
+  ROS_DEBUG("Hello, your number is %d", req.params.test);
   return true;
 }
 

--- a/op3_ball_detector/src/ball_detector.cpp
+++ b/op3_ball_detector/src/ball_detector.cpp
@@ -348,6 +348,7 @@ bool BallDetector::saveImageCallback(op3_ball_detector::SaveImage::Request &req,
 {
   // Basic debug statement to start
   ROS_DEBUG("Hello, your number is %d", req.params.test);
+  res.returns.test = 5;
   return true;
 }
 

--- a/op3_ball_detector/src/ball_detector.cpp
+++ b/op3_ball_detector/src/ball_detector.cpp
@@ -348,7 +348,15 @@ bool BallDetector::saveImageCallback(op3_ball_detector::SaveImage::Request &req,
 {
   // Basic debug statement to start
   ROS_DEBUG("Hello, your number is %d", req.params.test);
-  res.returns.test = 5;
+
+  if (cv_img_ptr_sub_ != NULL) {
+    cv::imwrite("~/out.png", cv_img_ptr_sub_->image);
+    res.returns.test = 0;
+  }
+  else {
+    res.returns.test = 1;
+  }
+
   return true;
 }
 

--- a/op3_ball_detector/srv/SaveImage.srv
+++ b/op3_ball_detector/srv/SaveImage.srv
@@ -1,0 +1,3 @@
+SaveImageParams  params
+---
+SaveImageParams  returns


### PR DESCRIPTION
This pull request is a bit of a back-fill since multiple cards have been completed under this request.

Cards this pull request addresses: 
Vision -- Tune and save data for given red ball
Vision -- Figure out how to take discrete pictures from stream

To test:

    Pull feature_vision_improv
    Checkout master
    Merge feature_vision_improv in
    Catkin make
    Test with robot

If you review this PR, please add your name and email below.

Reviewers:
Reviewed-by: Alice Michael <malice@pdx.edu>
Reviewed-by: Mel Flygare <mflygare@pdx.edu>