### PR TITLE
Replay: Fixed speed, changed replay file format, removed unused code

### DIFF
--- a/op3_motion_replay/include/op3_motion_replay/op3_motion_replay.h
+++ b/op3_motion_replay/include/op3_motion_replay/op3_motion_replay.h
@@ -49,7 +49,6 @@ namespace robotis_op{
 			ros::ServiceClient joint_module_;
 			
 			std::vector<sensor_msgs::JointState> joint_states_;
-			std::map<std::string, double> joint_angles_;
 			bool record_flag;
 	};
 }

--- a/op3_motion_replay/launch/replay.launch
+++ b/op3_motion_replay/launch/replay.launch
@@ -6,9 +6,6 @@
 	<param name = "init_file_path"   value="$(find op3_manager)/config/dxl_init_OP3.yaml"/>
 	<param name = "device_name"      value="/dev/ttyUSB0"/>
 
-	<param name="/robotis/direct_control/default_moving_time" value="0.04"/>
-	<param name="/robotis/direct_control/default_moving_angle" value="90"/>
-
 	<node pkg="op3_localization" type="op3_localization" name="op3_localization_motion_replay" output="screen"/>
 	<node pkg="op3_motion_replay" type="op3_motion_replay_node" name="op3_motion_replay_node" output="screen"/>
 </launch>

--- a/op3_motion_replay/src/op3_motion_replay.cpp
+++ b/op3_motion_replay/src/op3_motion_replay.cpp
@@ -65,6 +65,7 @@ namespace robotis_op
 	void MotionReplay::webCallback(const std_msgs::MultiArrayDimension::ConstPtr& msg){
 		switch(msg->size){
 			case REPLAY_START:
+				joint_states_.clear();
 				record_flag = !record_flag;
 				ROS_INFO("Button: start");
 				break;
@@ -150,10 +151,17 @@ namespace robotis_op
 		for (std::vector<sensor_msgs::JointState>::const_iterator it = joint_states_.begin();
 			 it != joint_states_.end(); ++it)
 		{
+			file << (*it).name << '\t';
+			file << (*it).position << '\t';
+			file << (*it).velocity << '\t';
+			file << (*it).effort;
+			file << '\n';
+		/*
 			for (std::vector<double>::const_iterator pit = (*it).position.begin();
 				 pit != (*it).position.end(); ++pit)
 				file << *pit << '\t';
 			file << '\n';
+		*/
 		}
 		
 		file.close();
@@ -193,15 +201,20 @@ namespace robotis_op
 		{
 			std::stringstream stream(data);
 			
-			while(getline(stream, token, delimiter))
-			{
-				msg.position.push_back(atof(token.c_str()));
-				ROS_INFO("%s\n", token.c_str());
-			}
+			getline(stream, token, delimiter);
+			msg.name.push_back(token);
+			
+			getline(stream, token, delimiter);
+			msg.position.push_back(atof(token.c_str()));
+			
+			getline(stream, token, delimiter);
+			msg.velocity.push_back(atof(token.c_str()));
+			
+			getline(stream, token);
+			msg.effort.push_back(atof(token.c_str()));
 			
 			joint_states_.push_back(msg);
-			msg.name.clear();
-			msg.position.clear();
+			msg.clear();
 		}
 		
 		file.close();

--- a/op3_motion_replay/src/op3_motion_replay.cpp
+++ b/op3_motion_replay/src/op3_motion_replay.cpp
@@ -140,11 +140,11 @@ namespace robotis_op
 
 		ROS_INFO("Current path is %s", get_current_dir_name());
 		std::ofstream file;
-		file.open(replay_name + ".txt");
+		file.open(replay_name + ".mrf");
 
 		if(!file.is_open())
 		{
-			message = "ERROR: failed to open " + replay_name + ".txt";
+			message = "ERROR: failed to open " + replay_name + ".mrf";
 			web_message.data = message;
 			web_message_pub_.publish(web_message);
 			ROS_INFO("%s", message.c_str());
@@ -168,7 +168,7 @@ namespace robotis_op
 
 		file.close();
 
-		message = replay_name + ".txt written.";
+		message = replay_name + ".mrf written.";
 		web_message.data = message;
 		web_message_pub_.publish(web_message);
 		ROS_INFO("%s", message.c_str());
@@ -181,11 +181,11 @@ namespace robotis_op
 		std::string message;
 
 		std::ifstream file;
-		file.open(replay_name + ".txt");
+		file.open(replay_name + ".mrf");
 
 		if(!file.is_open())
 		{
-			message = "ERROR: failed to open " + replay_name + ".txt";
+			message = "ERROR: failed to open " + replay_name + ".mrf";
 			web_message.data = message;
 			web_message_pub_.publish(web_message);
 			ROS_INFO("%s", message.c_str());
@@ -230,7 +230,7 @@ namespace robotis_op
 		}
 
 		file.close();
-		message = replay_name + ".txt loaded.";
+		message = replay_name + ".mrf loaded.";
 		web_message.data = message;
 		web_message_pub_.publish(web_message);
 		ROS_INFO("%s", message.c_str());
@@ -238,7 +238,7 @@ namespace robotis_op
 	}
 
 	void MotionReplay::deleteReplay(std::string file_name){
-		std::string file_path = file_name + ".txt";
+		std::string file_path = file_name + ".mrf";
 		std_msgs::String web_message;
 		std::string message;
 

--- a/op3_motion_replay/src/op3_motion_replay.cpp
+++ b/op3_motion_replay/src/op3_motion_replay.cpp
@@ -12,60 +12,62 @@ namespace robotis_op
 		MODULE_NAME("op3_motion_replay")
 	{
 		op3_joints_sub_ = nh_.subscribe("/robotis/present_joint_states", 1,
-										&MotionReplay::jointCallback, this);
+				&MotionReplay::jointCallback, this);
 		web_sub_ = nh_.subscribe("/robotis/replay/web", 1, &MotionReplay::webCallback, this);
 
 		web_message_pub_ = nh_.advertise<std_msgs::String>("/robotis/replay/status", 0);
 		joint_state_pub_ = nh_.advertise<sensor_msgs::JointState>("/robotis/direct_control/set_joint_states", 0);
 		module_pub_ = nh_.advertise<std_msgs::String>("/robotis/enable_ctrl_module", 0);
-				
+
 		joint_states_.clear();
-	 	joint_angles_.clear();	
+		joint_angles_.clear();	
 		record_flag = false;
 	}
 
 	MotionReplay::~MotionReplay()
 	{
-		
+
 	}
-	
+
 	void MotionReplay::enableModule(std::string module_name)
 	{
 		std_msgs::String msg;
 		msg.data = module_name;
 		module_pub_.publish(msg);
 	}
-	
+
 	void MotionReplay::jointCallback(const sensor_msgs::JointState::ConstPtr& msg)
 	{
 		if(!record_flag)
 			return;
-			
+
 		if(msg->name.size() == 0)
 			return;
-		
+
 		int num_states = msg->name.size();
-		
+
 		sensor_msgs::JointState new_msg;
-		
+
 		for(int i = 0; i < num_states; i++)
 		{
 			new_msg.name.push_back(msg->name[i]);
 			new_msg.position.push_back(msg->position[i]);
 			new_msg.velocity.push_back(msg->velocity[i]);
 			new_msg.effort.push_back(msg->effort[i]);
-			
+
 			ROS_INFO("%s\nposition: %f\nvelocity: %f\neffort: %f\n",
-					 msg->name[i].c_str(), msg->position[i], msg->velocity[i], msg->effort[i]);
+					msg->name[i].c_str(), msg->position[i], msg->velocity[i], msg->effort[i]);
 		}
-		
+
 		joint_states_.push_back(new_msg);
 	}
 
 	void MotionReplay::webCallback(const std_msgs::MultiArrayDimension::ConstPtr& msg){
 		switch(msg->size){
 			case REPLAY_START:
-				joint_states_.clear();
+				if(record_flag == false)
+					joint_states_.clear();
+
 				record_flag = !record_flag;
 				ROS_INFO("Button: start");
 				break;
@@ -79,7 +81,7 @@ namespace robotis_op
 				loadReplay(msg->label);
 				ROS_INFO("Button: load");
 				break;
-			
+
 			case REPLAY_DELETE:
 				deleteReplay(msg->label);
 				ROS_INFO("Button: delete");
@@ -96,7 +98,7 @@ namespace robotis_op
 				break;
 		}
 	}
-	
+
 	void MotionReplay::publishJointStates()
 	{
 		std_msgs::String web_message;
@@ -109,18 +111,18 @@ namespace robotis_op
 			ROS_INFO("%s", message.c_str());
 			return;
 		}
-		
-		ros::Rate loop_rate(30);
+
+		ros::Rate loop_rate(15);
 
 		for (std::vector<sensor_msgs::JointState>::const_iterator it = joint_states_.begin();
-			 it != joint_states_.end(); ++it)
+				it != joint_states_.end(); ++it)
 		{
-			 joint_state_pub_.publish(*it);
-			 loop_rate.sleep();
-       		 ROS_INFO("%f: \n", (*it).position[0]);
+			joint_state_pub_.publish(*it);
+			loop_rate.sleep();
+			ROS_INFO("%f: \n", (*it).position[0]);
 		}
 	}
-	
+
 	bool MotionReplay::saveReplay(std::string replay_name)
 	{
 		std_msgs::String web_message;
@@ -134,11 +136,11 @@ namespace robotis_op
 			ROS_INFO("%s", message.c_str());
 			return false;
 		}
-		
+
 		ROS_INFO("Current path is %s", get_current_dir_name());
 		std::ofstream file;
 		file.open(replay_name + ".txt");
-		
+
 		if(!file.is_open())
 		{
 			message = "ERROR: failed to open " + replay_name + ".txt";
@@ -147,32 +149,37 @@ namespace robotis_op
 			ROS_INFO("%s", message.c_str());
 			return false;
 		}
-		
+
 		for (std::vector<sensor_msgs::JointState>::const_iterator it = joint_states_.begin();
-			 it != joint_states_.end(); ++it)
+				it != joint_states_.end(); ++it)
 		{
-			file << (*it).name << '\t';
-			file << (*it).position << '\t';
-			file << (*it).velocity << '\t';
-			file << (*it).effort;
+			int len = (*it).name.size();
+			for(int i = 0; i < len; i++)
+			{
+				file << (*it).name[i] << ' ';
+				file << (*it).position[i] << ' ';
+				file << (*it).velocity[i] << ' ';
+				file << (*it).effort[i] << '\t';
+			}
+
 			file << '\n';
-		/*
-			for (std::vector<double>::const_iterator pit = (*it).position.begin();
-				 pit != (*it).position.end(); ++pit)
-				file << *pit << '\t';
-			file << '\n';
-		*/
+			/*
+			   for (std::vector<double>::const_iterator pit = (*it).position.begin();
+			   pit != (*it).position.end(); ++pit)
+			   file << *pit << '\t';
+			   file << '\n';
+			 */
 		}
-		
+
 		file.close();
-		
+
 		message = replay_name + ".txt written.";
 		web_message.data = message;
 		web_message_pub_.publish(web_message);
 		ROS_INFO("%s", message.c_str());
 		return true;
 	}
-	
+
 	bool MotionReplay::loadReplay(std::string replay_name)
 	{
 		std_msgs::String web_message;
@@ -180,7 +187,7 @@ namespace robotis_op
 
 		std::ifstream file;
 		file.open(replay_name + ".txt");
-		
+
 		if(!file.is_open())
 		{
 			message = "ERROR: failed to open " + replay_name + ".txt";
@@ -189,34 +196,44 @@ namespace robotis_op
 			ROS_INFO("%s", message.c_str());
 			return false;
 		}
-		
+
 		std::string data;
 		std::string token;
-		char delimiter = '\t';
+		std::string state;
+		char delimiter_tab = '\t';
+		char delimiter_space = ' ';
 		sensor_msgs::JointState msg;
-		
+
 		joint_states_.clear();
-		
+
 		while(getline(file, data))
 		{
 			std::stringstream stream(data);
-			
-			getline(stream, token, delimiter);
-			msg.name.push_back(token);
-			
-			getline(stream, token, delimiter);
-			msg.position.push_back(atof(token.c_str()));
-			
-			getline(stream, token, delimiter);
-			msg.velocity.push_back(atof(token.c_str()));
-			
-			getline(stream, token);
-			msg.effort.push_back(atof(token.c_str()));
-			
+
+			while(getline(stream, state, delimiter_tab))
+			{
+				std::stringstream stream_state(state);
+
+				getline(stream_state, token, delimiter_space);
+				msg.name.push_back(token);
+
+				getline(stream_state, token, delimiter_space);
+				msg.position.push_back(atof(token.c_str()));
+
+				getline(stream_state, token, delimiter_space);
+				msg.velocity.push_back(atof(token.c_str()));
+
+				getline(stream_state, token);
+				msg.effort.push_back(atof(token.c_str()));
+			}
+
 			joint_states_.push_back(msg);
-			msg.clear();
+			msg.name.clear();
+			msg.position.clear();
+			msg.velocity.clear();
+			msg.effort.clear();
 		}
-		
+
 		file.close();
 		message = replay_name + ".txt loaded.";
 		web_message.data = message;
@@ -229,7 +246,7 @@ namespace robotis_op
 		std::string file_path = file_name + ".txt";
 		std_msgs::String web_message;
 		std::string message;
-		
+
 		if(remove(file_path.c_str()) == 0){
 			message = "Removed " + file_path;
 			web_message.data = message;

--- a/op3_motion_replay/src/op3_motion_replay_node.cpp
+++ b/op3_motion_replay/src/op3_motion_replay_node.cpp
@@ -8,6 +8,15 @@ int main(int argc, char **argv)
   ros::Rate loop_rate(30);
 
   robotis_op::MotionReplay *op3_motion_replay = new robotis_op::MotionReplay();
+  
+  while(ros::ok()){
+    ros::Duration(1.0).sleep();
+    if(isManagerRunning() == true){
+      break;
+      ROS_INFO("Connected to op3_manager.");
+    }
+    ROS_WARN("Waiting for op3_manager...");
+  }
 
   ROS_INFO("Start motion replay");
 
@@ -17,4 +26,17 @@ int main(int argc, char **argv)
   }
 
   return 0;
+}
+
+bool isManagerRunning(){
+  std::vector<std::string> nodes;
+  ros::master::getNodes(nodes);
+  std::string manager_name = "/op3_manager";
+
+  for (unsigned int nodes_idx = 0; nodes_idx < nodes.size(); nodes_idx++){
+    if(nodes[nodes_idx] == manager_name)
+      return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
Cards this pull request addresses:
Replay -- Speed up Replay to match recording speed

Changed file format of replays from ".txt" to ".mrf" to restrict file deletion.
Removed comments and unused code.

To test:
Pull feature_replay_dev to catkin_ws/src
Run catkin_make
Test on robot
-run "roslaunch op3_motion_replay replay.launch"
-recording requires first playing an action for verifying accurate replay

If you review this PR, please add your name and email below.
Reviewers: